### PR TITLE
Fix mass sample import file duplication

### DIFF
--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -343,7 +343,7 @@ void FileBrowser::expandItems(const QList<QString>& expandedDirs, QTreeWidgetIte
 	if (expandedDirs.isEmpty()) { return; }
 
 	int numChildren = item ? item->childCount() : m_fileBrowserTreeWidget->topLevelItemCount();
-	for (int i = 0; i <= numChildren; ++i)
+	for (int i = 0; i < numChildren; ++i)
 	{
 		auto it = item ? item->child(i) : m_fileBrowserTreeWidget->topLevelItem(i);
 		auto d = dynamic_cast<Directory*>(it);


### PR DESCRIPTION
A typo caused the directory to iterate over one more file than actually exists within the folder, resulting in LMMS's directory import to always import the last sample twice.  This fixes that.